### PR TITLE
Add bc to the list of installed packages

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Read it first : https://github.com/android-rpi/local_manifests/tree/arpi-11
 
 # Build Kernel
-  $ sudo apt install gcc-aarch64-linux-gnu libssl-dev
+  $ sudo apt install gcc-aarch64-linux-gnu libssl-dev bc
   $ cd kernel/arpi
   $ ARCH=arm64 scripts/kconfig/merge_config.sh arch/arm64/configs/bcm2711_defconfig kernel/configs/android-base.config kernel/configs/android-recommended.config
   $ ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- make Image.gz


### PR DESCRIPTION
On my server Debian 10 installation the `bc` package was not installed by default which caused the `Image.gz` compilation to fail, so I've added it to the the `apt install` list.